### PR TITLE
Coarray fix, readability/style enhancement

### DIFF
--- a/src/ch01/array_copy_caf.f90
+++ b/src/ch01/array_copy_caf.f90
@@ -18,7 +18,7 @@ write(*,'(a,i2,a,5(4x,i2))')'array on proc ', this_image(),&
 
 sync all
 
-array(:)[2] = array(:)[1]
+if (this_image() == 2) array(:) = array(:)[1]
 
 write(*,'(a,i2,a,5(4x,i2))')'array on proc ', this_image(),&
   ' after copy: ', array

--- a/src/ch01/array_copy_caf.f90
+++ b/src/ch01/array_copy_caf.f90
@@ -19,7 +19,7 @@ write(*,'(a,i2,a,5(4x,i2))')'array on proc ', this_image(),&
 
 sync all
 
-if (this_image() == receiver) array(:) = array(:)[sender]
+if (this_image() == receiver) array = array[sender]
 
 write(*,'(a,i2,a,5(4x,i2))')'array on proc ', this_image(),&
   ' after copy: ', array

--- a/src/ch01/array_copy_caf.f90
+++ b/src/ch01/array_copy_caf.f90
@@ -2,12 +2,13 @@ program array_copy_caf
 implicit none
 
 integer, dimension(5), codimension[*] :: array
+integer, parameter :: sender = 1, receiver = 2
 
 if (num_images() /= 2) then
   stop 'Error: This program must be run on 2 parallel processes'
 end if
 
-if (this_image() == 1) then
+if (this_image() == sender) then
   array = [1, 2, 3, 4, 5]
 else
   array = 0
@@ -18,7 +19,7 @@ write(*,'(a,i2,a,5(4x,i2))')'array on proc ', this_image(),&
 
 sync all
 
-if (this_image() == 2) array(:) = array(:)[1]
+if (this_image() == receiver) array(:) = array(:)[sender]
 
 write(*,'(a,i2,a,5(4x,i2))')'array on proc ', this_image(),&
   ' after copy: ', array

--- a/src/ch01/array_copy_mpi.f90
+++ b/src/ch01/array_copy_mpi.f90
@@ -7,6 +7,7 @@ integer :: ierr, nproc, procsize, request
 integer, dimension(mpi_status_size) :: stat
 
 integer, dimension(5) :: array
+integer, parameter :: sender = 0, receiver = 1
 
 call mpi_init(ierr)
 call mpi_comm_rank(mpi_comm_world, nproc, ierr)
@@ -17,7 +18,7 @@ if (procsize /= 2) then
   stop 'Error: This program must be run on 2 parallel processes'
 end if
 
-if (nproc == 0) then
+if (nproc == sender) then
   array = [1, 2, 3, 4, 5]
 else
   array = 0
@@ -28,11 +29,11 @@ write(*,'(a,i2,a,5(4x,i2))')'array on proc ', nproc,&
 
 call mpi_barrier(mpi_comm_world, ierr)
 
-if (nproc == 0) then
-  call mpi_isend(array, size(array), mpi_int, 1, 1,&
+if (nproc == sender) then
+  call mpi_isend(array, size(array), mpi_int, receiver, 1,&
                  mpi_comm_world, request, ierr)
-else if (nproc == 1) then
-  call mpi_irecv(array, size(array), mpi_int, 0, 1,&
+else if (nproc == receiver) then
+  call mpi_irecv(array, size(array), mpi_int, sender, 1,&
                  mpi_comm_world, request, ierr)
   call mpi_wait(request, stat, ierr)
 end if


### PR DESCRIPTION
Feel free to just cherry pick the first commit or implement suggestions manually yourself.

This PR addresses:

 - Double copy of CAF variable (causes undefined behavior according to MRC)
 - Makes the arguments to MPI funcs clearer by reducing the number of "magic numbers"