### PR TITLE
Opencoarray on Mac only for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,11 @@ before_install:
       brew update;
       brew install gcc;
       brew install open-mpi;
+      export FC=gfortran;
     fi
 
 install: 
-    - make -k || true
+    - make array_copy_mpi
     
 script:
     - mpirun -n 2 ./array_copy_mpi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,6 @@ script:
     - mpirun -n 2 ./array_copy_mpi
 # FIXME: Ubuntu 14.04 is too old for opencoarrays.  Would Linuxbrew work?
     - if [[ $TRAVIS_OS_NAME == osx ]]; then
-        cafrun -n 2 ./array_copy_caf
-        cafrun -n 2 ./hello_coarrays
+        cafrun -n 2 ./array_copy_caf;
+        cafrun -n 2 ./hello_coarrays;
       fi

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ make -k
 -k
 : continue to `make` even if one command fails (for those that don't have `caf` compiler wrapper, for example).
 
+or, you can select to make particular programs by:
+```sh
+make array_copy_mpi
+```
+
 ### Linux
 Get the `mpif90` compiler wrapper on Ubuntu &ge; 12.04:
 ```sh


### PR DESCRIPTION
Opencoarray needs Ubuntu &ge; 17.04  or Linuxbrew. For now I just made `caf` only run on `osx` to avoid the nuisance error.

The PPA didn't seem necessary and was for Ubuntu 12.04 instead of 14.04 that this .travis.yml uses.

It seems CMake 2.8.12 is adequate for what's being done currently.
